### PR TITLE
Added ev3_wait function to the EV3 API

### DIFF
--- a/common/ev3api/src/ev3api.c
+++ b/common/ev3api/src/ev3api.c
@@ -57,3 +57,8 @@ void *__dso_handle __attribute__((weak))=0;
  * See 'http://wiki.osdev.org/Calling_Global_Constructors' for details of '.fini_array' and '_fini' in ARM.
  */
 void __attribute__((weak)) _fini() {}
+
+void ev3_wait(unsigned int milliSec) {
+    ER ercd = dly_tsk(milliSec * 1000U);
+    assert(ercd == E_OK);
+}


### PR DESCRIPTION
I couldn't find one already in the API and it makes sense to have an easy way to add blocking delays for x milliseconds. If I just missed an existing function to do this, I can just close this PR. I also don't know where exactly is the best place to put the function in the API code so if where I put it isn't good tell me and I can move it. There also isn't a definition of it in a `.h` file and I don't know if this is necessary.
Also if this goes through I will create an identical PR for the `ev3rt-hrp2-sdk` repo.